### PR TITLE
capx: upgrade-workflow memory (conf only, no code)

### DIFF
--- a/.claude/memory/capi-upgrade/capi-upgrade.conf
+++ b/.claude/memory/capi-upgrade/capi-upgrade.conf
@@ -1,0 +1,15 @@
+UPSTREAM_URL=https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack.git
+PROVIDER=capc
+SPECTRO_SRC=origin/spectro-main
+MANDATORY_PATTERNS=Added Spectro Manifests|exclusive webhook|Spectro CICD|self hosted runner|RBAC|ServiceAccount
+GENERATED_PATHS=config/|spectro/base|spectro/global|zz_generated
+# F4_HOTSPOTS: populate on first triage (per-repo; empty is safe — unknowns route to NEEDS-DECISION)
+F4_HOTSPOTS=
+# --- integration/validation tail (Spec Patch) ---
+CLOUD=cloudstack
+CBT_FEATURE=lifecycle   # ally/tests/cbt go-test suite (NOT make cbt-<cloud>); select per cloud
+VENDORCRD=config/vendorcrd/apache-cloudstack     # confirm exact config/vendorcrd/<dir>
+BUILD_VARS_ENABLED=1
+BUILD_VARS_MAKEFILE=Makefile
+BUILD_VARS_TAG_KEY=TAG
+BUILD_VARS_GO_KEY=BUILDER_GOLANG_VERSION

--- a/.claude/memory/capi-upgrade/capi-upgrade.md
+++ b/.claude/memory/capi-upgrade/capi-upgrade.md
@@ -1,0 +1,5 @@
+# capc — CAPI Upgrade Ledger (stub)
+
+First cycle — populate after first plan.
+- Source: origin/spectro-main
+- Target: TBD (latest upstream release tag)

--- a/.claude/memory/capi-upgrade/known-commits.tsv
+++ b/.claude/memory/capi-upgrade/known-commits.tsv
@@ -1,0 +1,1 @@
+# authoritative SHA<TAB>CAT<TAB>decision<TAB>note — populate on first run

--- a/.claude/memory/capi-upgrade/skip-commits.txt
+++ b/.claude/memory/capi-upgrade/skip-commits.txt
@@ -1,0 +1,1 @@
+# explicit human skip decisions (SHA per line; # = comment)


### PR DESCRIPTION
## CAPx upgrade workflow — per-repo memory (conf only, no code)

Seeds `.claude/memory/capi-upgrade/capi-upgrade.conf` so the Luma Protocol U engine
(`spectro-capx-upgrade` plugin) can plan/execute upgrades on this fork: PROVIDER/UPSTREAM_URL/
SPECTRO_SRC identity, SKIP/MANDATORY patterns, and the integration-tail keys (CLOUD, CBT_FEATURE,
VENDORCRD, BUILD_VARS_*). Decision ledgers (skip/resolve/regwatch) arrive with this fork's first
upgrade cycle — same layout as cluster-api#290 / capg#287 / capa#1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
